### PR TITLE
Remove build from plastid version specification

### DIFF
--- a/code/envs/plastid.yml
+++ b/code/envs/plastid.yml
@@ -4,4 +4,5 @@ channels:
     - defaults
 dependencies:
     - numpy<=1.11.3
-    - plastid=0.4.8=py36h84994c4_4
+      # - plastid=0.4.8=py36h84994c4_4
+    - plastid=0.4.8


### PR DESCRIPTION
The build string is different for Linux and MacOS.
There is a newer build (5) avail as well. Hopefully this will get picked
up properly by conda in new environments.
This will likely no longer be an issue (at least not as much of one)
if/when plastid 0.4.9 is released.