### PR TITLE
Added all_downloads rule

### DIFF
--- a/code/rules/genome.smk
+++ b/code/rules/genome.smk
@@ -3,6 +3,13 @@ FTP = FTPRemoteProvider()
 
 ruleorder: get_fasta_ftp > gunzip
 
+rule all_downloads:
+    input:
+        config["genome_fasta_file"],
+        config["genome_annotation_gff3_file"],
+        config["genome_annotation_gtf_file"],
+
+
 rule get_fasta_ftp:
     input:
         FTP.remote(config["genome_fasta_ftp"], keep_local=True)


### PR DESCRIPTION
Added an `all_downloads` rule that simplifies the task of running just the genome download portion of the workflow

So, for example, to download all three genome files, one at a time:

```
snakemake --cores 1 -s code/mito_codontable.snakefile all_downloads
```

If one specifies more cores, it will attempt to download more than one at a time.