### PR TITLE
Restrict gunzip rule to prevent PeriodicWildcardError

### DIFF
--- a/code/rules/genome.smk
+++ b/code/rules/genome.smk
@@ -63,7 +63,8 @@ rule gunzip:
     input:
         "{file}.gz"
     output:
-        "{file}"
+        # This crazy regex actually means the output can't end in `.gz`
+        "{file,^((?!\.gz).)*$}"
     shell:
         "gunzip -c {input:q} > {output:q}"
 


### PR DESCRIPTION
Hopefully makes debugging a bit easier by reducing the chance an upstream error will show up as a `PeriodicWildcardError`. See FAQ entry [Snakemake complains about a cyclic dependency or a PeriodicWildcardError. What can I do?](https://snakemake.readthedocs.io/en/stable/project_info/faq.html#snakemake-complains-about-a-cyclic-dependency-or-a-periodicwildcarderror-what-can-i-do) for some explanation.