### PR TITLE
Pin plastid to version 0.5.1

### DIFF
--- a/code/envs/plastid.yml
+++ b/code/envs/plastid.yml
@@ -3,4 +3,4 @@ channels:
     - bioconda
     - defaults
 dependencies:
-    - plastid>=0.5.1
+    - plastid==0.5.1


### PR DESCRIPTION
Later plastid versions made backwards incompatible changes to `Transcript`.

This PR is a quick fix for issue #58.